### PR TITLE
(Makefile.common) Correct the logic of conditional

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -368,7 +368,7 @@ ifeq ($(HAVE_LIGHTREC), 1)
                   $(DEPS_DIR)/lightrec/memmanager.c \
                   $(DEPS_DIR)/lightrec/optimizer.c \
                   $(DEPS_DIR)/lightrec/regcache.c
-   ifneq (,$(findstring win,$(platform)))
+   ifeq (,$(findstring win,$(platform)))
        SOURCES_C +=   $(DEPS_DIR)/lightrec/recompiler.c
    endif
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -147,7 +147,7 @@ endif
 ifeq ($(HAVE_LIGHTREC), 1)
    FLAGS += -DHAVE_LIGHTREC \
             -DHAVE_FFSL
-   ifeq (,$(findstring win,$(platform)))
+   ifneq (,$(findstring win,$(platform)))
        FLAGS += -DENABLE_FIRST_PASS=0 -DENABLE_THREADED_COMPILER=0
    else
        FLAGS += -DENABLE_FIRST_PASS=1 -DENABLE_THREADED_COMPILER=1


### PR DESCRIPTION
If the value of "findstring win" in "platform" is equal to an empty string, then we're probably **NOT** on Windows.
This way, recompiler.c will be compiled on every "platform" except Windows.